### PR TITLE
Handling connection error during command execution and destroying the connection

### DIFF
--- a/aut/au/condor/controllers/protocols/telnet.py
+++ b/aut/au/condor/controllers/protocols/telnet.py
@@ -223,7 +223,7 @@ class Telnet(Protocol):
                     state = 2
                     timeout = 10
                     continue
-                
+
                 if state == 2:
                     state = 4
                     timeout = 10

--- a/aut/au/condor/platforms/generic.py
+++ b/aut/au/condor/platforms/generic.py
@@ -192,7 +192,15 @@ class Connection(object):
             _logger.debug(
                 _c(self.hostname, "Sending command: '{}'".format(cmd)))
 
-            self._execute_command(cmd, timeout, wait_for_string)
+            try:
+                self._execute_command(cmd, timeout, wait_for_string)
+            except ConnectionError:
+                _logger.warn(
+                    _c(self.hostname,
+                        "Connection lost. Disconnecting."))
+                self.disconnect()
+                raise
+
             _logger.info(
                 _c(self.hostname,
                    "Command executed successfully: '{}'".format(cmd)))


### PR DESCRIPTION
When the connection error is detected either unexpected or caused by the command (exit, reload) then the respective exception is raised and connection is destroyed. It fixes the situation when after device reload the connection stays active but referring to jumphost not the destined device.
After catching ConnectionError exception during command execution the code should execute connect method again. No explicit disconnect method call is needed anymore.
