### PR TITLE
Additional NCS4K enabling

### DIFF
--- a/csmserver/constants.py
+++ b/csmserver/constants.py
@@ -90,6 +90,7 @@ class PlatformFamily:
     ASR900 = 'ASR900'
     CRS = 'CRS'
     NCS1K = 'NCS1K'
+    NCS4K = 'NCS4K'
     NCS5K = 'NCS5K'
     NCS5500 = 'NCS5500'
     NCS6K = 'NCS6K'

--- a/csmserver/package_utils.py
+++ b/csmserver/package_utils.py
@@ -64,7 +64,7 @@ def get_target_software_package_list(family, os_type, host_packages, target_vers
                     # asr9k-mgbl-px.pie-5.3.3, hfr-mgbl-px.pie-5.3.3
                     target_list.append('{}-px.pie-{}'.format(package_name, target_version))
 
-        elif software_platform in PlatformFamily.NCS6K:
+        elif software_platform in [PlatformFamily.NCS6K, PlatformFamily.NCS4K]:
             match = re.search('-\d+\.\d+\.\d+', host_package)
             if not match:
                 continue
@@ -73,16 +73,20 @@ def get_target_software_package_list(family, os_type, host_packages, target_vers
             if match_internal_name:
                 if '-xr-' in host_package:
                     # ncs6k-mgbl-5.2.4
+                    # ncs4k-mgbl-6.0.2
                     target_list.append('{}-{}'.format(family.lower() + '-mini-x', target_version))
                 else:
                     # ncs6k-mini-x-5.2.4
+                    # ncs4k-mini-x-6.0.2
                     target_list.append('{}-{}'.format(package_name, target_version))
             else:
                 if '-xr-' in host_package:
                     # ncs6k-mini-x.iso-5.2.4
+                    # ncs4k-mini-x.iso-6.0.2
                     target_list.append('ncs6k-mini-x.iso-{}'.format(target_version))
                 else:
                     # ncs6k-mgbl.pkg-5.2.4
+                    # ncs4k-mgbl.pkg-6.0.2
                     target_list.append('{}.pkg-{}'.format(package_name, target_version))
 
         elif software_platform in [PlatformFamily.ASR9K_64, PlatformFamily.NCS1K,
@@ -130,6 +134,7 @@ def is_file_acceptable_for_install_add(filename):
     """
     ASR9K, CRS: .pie, .tar
     NCS6K: .smu, .iso, .pkg, .tar
+    NCS4K: .iso .pkg
     ASR9K-64: .iso, .rpm, .tar
     ASR900: .bin
     """

--- a/csmserver/parsers/__init__.py
+++ b/csmserver/parsers/__init__.py
@@ -38,6 +38,7 @@ def get_parser_factory(software_platform, os_type):
                                PlatformFamily.IOSXRv]:
         return NCS1K5KIOSXRvParserFactory()
     elif software_platform in [PlatformFamily.ASR9K_64,
+                               PlatformFamily.NCS4K,
                                PlatformFamily.NCS6K,
                                PlatformFamily.NCS5500]:
         return EXRParserFactory()

--- a/csmserver/parsers/platforms/eXR.py
+++ b/csmserver/parsers/platforms/eXR.py
@@ -316,12 +316,16 @@ class EXRInventoryParser(BaseInventoryParser):
 
     def process_inventory(self, ctx):
         """
-        For ASR9K-64, NCS6K and NCS5500
+        For ASR9K-64, NCS4K, NCS6K and NCS5500
         Chassis most likely shows up first in the
         output of "admin show inventory".
         Example for ASR9K-64:
         Name: Rack 0                Descr: ASR-9904 AC Chassis
         PID: ASR-9904-AC            VID: V01                   SN: FOX1746GHJ9
+
+        Example for NCS4K:
+        Name: Rack 0                Descr: NCS 4016 shelf assembly - DC Power
+        PID: NCS4016-SA-DC          VID: V01                   SN: SAL1931LDUG
 
         Example for NCS6K:
         Name: Rack 0                Descr: NCS 6008 - 8-Slot Chassis


### PR DESCRIPTION
Enable NCS4K in PlatformFamily, pacakges_util, and platform parsers.