### PR TITLE
fix asr9k-x64 iso filename convention

### DIFF
--- a/csmserver/package_utils.py
+++ b/csmserver/package_utils.py
@@ -119,8 +119,8 @@ def get_target_software_package_list(family, os_type, host_packages, target_vers
                         # ncs5k-mini-x.iso-6.1.1
                         target_list.append("{}-{}-{}".format(family.lower(), 'mini-x.iso', target_version))
                     elif software_platform in [PlatformFamily.ASR9K_64]:
-                        # asr9k-mini-x64.iso-6.1.1
-                        target_list.append("{}-{}-{}".format(family.lower(), 'mini-x64.iso', target_version))
+                        # asr9k-mini-x64-6.1.3.iso
+                        target_list.append("{}-{}-{}{}".format(family.lower(), 'mini-x64', target_version), '.iso')
                 else:
                     # asr9k-mgbl-x64-3.0.0.0-r601.x86_64.rpm, ncs5k-mgbl-3.0.0.0-r611.x86_64.rpm-6.1.1
                     target_list.append("{}-{}-{}.{}".format(package_name, '\d\.\d\.\d.\d',


### PR DESCRIPTION
For ASR9K eXR, CSM is looking for ‘asr9k-mini-x64.iso-6.2.1’ but in the CCO folder the filename is ‘asr9k-mini-x64-6.2.1.iso’.